### PR TITLE
Add support for application-defined claims

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
         rust-toolchain: [1.49.0]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
+    environment: test
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -40,8 +41,14 @@ jobs:
     - name: Install audit
       run: cargo install cargo-audit
       shell: bash 
-    - name: Download OIDC metadata
-      run: mkdir -p ~/src/well-known && curl -sLX GET https://accounts.google.com/.well-known/openid-configuration > ~/src/well-known/openid-configuration.json && curl -sLX GET https://www.googleapis.com/oauth2/v3/certs > ~/src/well-known/jwks.json
+    - name: Prepare to store metadata
+      run: mkdir -p src/well-known
+      shell: bash
+    - name: Store JWKS metadata
+      run: echo "${{ secrets.JWKS_JSON }}" > src/well-known/jwks.json
+      shell: bash    
+    - name: Store OIDC metadata
+      run: echo "${{ secrets.OIDC_METADATA_JSON }}" > src/well-known/openid-configuration.json
       shell: bash
     - name: fmt
       run: cargo fmt
@@ -55,4 +62,3 @@ jobs:
     - name: build
       run: cargo build
       shell: bash
-      

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "compute-rust-auth"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "fastly",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "fastly"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca20e271eada2398e7a3042fdbe1a8daa021e50516f21a24f8db4c94edd020b"
+checksum = "b902d81a7be2a0bfc504bf82e5f28db32da16c390e4a40660b66fa9ba0d21012"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -218,7 +218,6 @@ dependencies = [
  "fastly-sys",
  "http",
  "lazy_static",
- "log",
  "mime",
  "serde",
  "serde_json",
@@ -251,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.3.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d737b5a765b8d09647911dd4d5f75695d290bcdc165103dbeaea189cea837bd"
+checksum = "1a62f76ee7ad35f28e2e2b84a36dd6f1781dd61a139151f3550bd539714b22f0"
 dependencies = [
  "fastly-shared",
 ]
@@ -346,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "hmac-sha256"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219d368c625166098039429766941449ebf303da35d642eb339503a2bdad3423"
+checksum = "bcdc571e566521512579aab40bf807c5066e1765fb36857f16ed7595c13567c6"
 dependencies = [
  "digest",
 ]
@@ -756,18 +755,18 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compute-rust-auth"
-version = "0.1.0"
+version = "0.2.0"
 authors = []
 edition = "2018"
 
@@ -8,10 +8,10 @@ edition = "2018"
 debug = true
 
 [dependencies]
-fastly = "0.7.0"
-hmac-sha256 = "0.1.6"
+fastly = "0.7.1"
+hmac-sha256 = "0.1.7"
 rand = "0.8.3"
-serde = { version = "1.0.124", features = ["derive"] }
+serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 base64 = "0.13.0"
 toml = "0.5.8"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It includes [JSON Web Token (JWT)](https://oauth.net/2/jwt/) verification, and [
 
 Scroll down to view [the flow in more detail](#the-flow-in-detail).
 
-For Compute@Edge starter kits, visit the [Fastly Developer Hub](https://developer.fastly.com/solutions/starters/). 
+Read [the blog post](https://www.fastly.com/blog/simplifying-authentication-with-oauth-at-the-edge) to learn why this is a good idea. For Compute@Edge starter kits, visit the [Fastly Developer Hub](https://developer.fastly.com/solutions/starters/). 
 
 ---
 
@@ -85,7 +85,7 @@ Add `https://{some-funky-words}.edgecompute.app/callback` to the list of allowed
 
 ## The flow in detail
 
-![Edge authentication flow diagram](https://user-images.githubusercontent.com/12828487/111877650-1c70f380-899c-11eb-98ba-427e4006f58a.png)
+![Edge authentication flow diagram](https://user-images.githubusercontent.com/12828487/115379253-4438be80-a1c9-11eb-81af-9470e324434a.png)
 
 1. The user makes a request for a protected resource, but they have no session cookie.
 1. At the edge, this service generates:

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -9,7 +9,7 @@ pub fn parse(cookie_string: &str) -> HashMap<&str, &str> {
         .filter_map(|kv| {
             kv.find('=').map(|index| {
                 let (key, value) = kv.split_at(index);
-                let key = key.trim();
+                let mut key = key.trim();
                 if key.starts_with(&COOKIE_PREFIX) {
                     key = &key[..(key.len() - COOKIE_PREFIX.len())];
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use config::Config;
 use fastly::http::header::AUTHORIZATION;
 use fastly::{Error, Request, Response};
 use idp::{AuthCodePayload, AuthorizeResponse, CallbackQueryParameters, ExchangePayload};
+use jwt_simple::claims::NoCustomClaims;
 use jwt::{validate_token_rs256, NonceToken};
 use pkce::{rand_chars, Pkce};
 
@@ -102,13 +103,13 @@ fn main(mut req: Request) -> Result<Response, Error> {
             }
         // Validate the JWT access token.
         } else if settings.config.jwt_access_token
-            && validate_token_rs256(access_token, &settings).is_err()
+            && validate_token_rs256::<NoCustomClaims>(access_token, &settings).is_err()
         {
             return Ok(responses::unauthorized("JWT access token invalid."));
         }
 
         // Validate the ID token.
-        if validate_token_rs256(id_token, &settings).is_err() {
+        if validate_token_rs256::<NoCustomClaims>(id_token, &settings).is_err() {
             return Ok(responses::unauthorized("ID token invalid."));
         }
 


### PR DESCRIPTION
# Changes

- Adds (optional) [support for application-defined claims](https://docs.rs/jwt-simple/0.9.4/jwt_simple/index.html#token-verification) for `validate_token_rs256`, in addition to all standard JWT claims. This is now possible:
  ```rs
  #[derive(serde::Serialize, serde::Deserialize)]
  struct MyCustomClaims {
      email: String,
      country: String,
  }
  
  if let Ok(claims) = validate_token_rs256::<MyCustomClaims>(token_string, &settings) {
        // claims.custom is an instance of MyCustomClaims
        req.set_header("Fastly-Auth-Email", claims.custom.email);
        req.set_header("Fastly-Auth-Country", claims.custom.country);
  }
  ```
- Upgrades all dependencies.
- Adds a link to [a relevant blog post](https://www.fastly.com/blog/simplifying-authentication-with-oauth-at-the-edge) and updates the flow diagram in README.

# Fixes

- CI test workflow updated to source the OpenID and JWKS metadata from environment secrets.
- Reassignment of a non-mutable key value in `cookie::parse`.