### PR TITLE
override newline

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -86,7 +86,7 @@ echo -e "
 
 👩‍💻 Running \033[1mfastly service-version clone --service-id=$SERVICE_ID --version=$VERSION\033[0m
 "
-NEXT_VERSION=$(fastly service-version clone --service-id=$SERVICE_ID --version=$VERSION | awk '{ printf $NF }')
+NEXT_VERSION=$(fastly service-version clone --service-id=$SERVICE_ID --version=$VERSION | awk '{ printf "%s", $NF }')
 
 createTlsBackend() {
     echo -e "

--- a/setup.sh
+++ b/setup.sh
@@ -80,13 +80,13 @@ fastly compute deploy
 printInGreen "All set! Let's create the backends for your origin and the authorization server."
 
 SERVICE_ID=$(awk -F'[ ="]+' '$1 == "service_id" { print $2 }' fastly.toml)
-VERSION=$(awk -F'[ =]+' '$1 == "version" { print $2 }' fastly.toml)
+VERSION=$(awk -F'[ =]+' '$1 == "manifest_version" { print $2 }' fastly.toml)
 
 echo -e "
 
 👩‍💻 Running \033[1mfastly service-version clone --service-id=$SERVICE_ID --version=$VERSION\033[0m
 "
-NEXT_VERSION=$(fastly service-version clone --service-id=$SERVICE_ID --version=$VERSION | awk '{ print $NF }')
+NEXT_VERSION=$(fastly service-version clone --service-id=$SERVICE_ID --version=$VERSION | awk '{ printf $NF }')
 
 createTlsBackend() {
     echo -e "

--- a/setup.sh
+++ b/setup.sh
@@ -80,7 +80,7 @@ fastly compute deploy
 printInGreen "All set! Let's create the backends for your origin and the authorization server."
 
 SERVICE_ID=$(awk -F'[ ="]+' '$1 == "service_id" { print $2 }' fastly.toml)
-VERSION=$(awk -F'[ =]+' '$1 == "manifest_version" { print $2 }' fastly.toml)
+VERSION=$(awk -F'[ =]+' '$1 == "version" { print $2 }' fastly.toml)
 
 echo -e "
 


### PR DESCRIPTION
This PR addresses ~two issues~ an issue I encountered while running `setup.sh`.

~1. `fastly compute init` appears to create a fastly.toml with `manifest_version` rather than `version`.~ [My change seems like an abuse of the `manifest_version` field.]
1.  Setting `$NEXT_VERSION` to the output of `print $NF` results in a newline before the version.

Tested using Fastly CLI version 0.27.2 (7795612) on Mac OS 11.2.3.