### PR TITLE
Fetch the active service version on setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -80,7 +80,7 @@ fastly compute deploy
 printInGreen "All set! Let's create the backends for your origin and the authorization server."
 
 SERVICE_ID=$(awk -F'[ ="]+' '$1 == "service_id" { print $2 }' fastly.toml)
-VERSION=$(awk -F'[ =]+' '$1 == "version" { print $2 }' fastly.toml)
+VERSION=$(fastly service-version list --service-id=$SERVICE_ID | awk '/true/{ printf $1 }')
 
 echo -e "
 


### PR DESCRIPTION
Now that the [`fastly.toml` manifest version 1](https://developer.fastly.com/reference/fastly-toml/) has stabilised, we should fetch the active service `version` from the service version list ([relevant command](https://developer.fastly.com/reference/cli/service-version/list/) using the [latest fastly CLI](https://developer.fastly.com/reference/cli/#installing)) instead of the package manifest.