### PR TITLE
Expire access_token and id_token cookies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,8 +72,8 @@ fn main(mut req: Request) -> Result<Response, Error> {
                     // Replay the original request, setting the tokens as cookies.
                     Ok(responses::temporary_redirect(
                         original_req,
-                        cookies::session("access_token", &auth.access_token),
-                        cookies::session("id_token", &auth.id_token),
+                        cookies::persistent("access_token", &auth.access_token, auth.expires_in),
+                        cookies::persistent("id_token", &auth.id_token, auth.expires_in),
                         cookies::expired("code_verifier"),
                         cookies::expired("state"),
                     ))


### PR DESCRIPTION
Currently the access_token and id_token cookies are session cookies, so they expire in the browser when the current browser session ends. However, the tokens have a limited lifetime on the identity provider, so sending the cookies past their lifetime leads to an unauthorized error.

This change makes the access_token and id_token cookies expire when they expire on the identity provider. This leads to a better user experience.