### PR TITLE
Adding service version logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ use pkce::{rand_chars, Pkce};
 
 #[fastly::main]
 fn main(mut req: Request) -> Result<Response, Error> {
+    // Log service version
+    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
+    
     // Load the service configuration, and the OpenID discovery and token signature metadata.
     let settings = Config::load();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,11 @@ use pkce::{rand_chars, Pkce};
 #[fastly::main]
 fn main(mut req: Request) -> Result<Response, Error> {
     // Log service version
-    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
-    
+    println!(
+        "FASTLY_SERVICE_VERSION: {}",
+        std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new())
+    );
+
     // Load the service configuration, and the OpenID discovery and token signature metadata.
     let settings = Config::load();
 


### PR DESCRIPTION
Prints service version to console after running `fastly log-tail`. ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiMDY0MmI0YThjZDVhNGE5NjljZjBiZGNjNTkzOWY2NDMiLCJwIjoiaiJ9))