### PR TITLE
Validate issuer from key metadata and not OIDC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 base64 = "0.21.0"
 toml = "0.5.9"
-jwt-simple = "0.11.4"
+jwt-simple = "0.11.6"

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,7 @@ pub struct JsonWebKey<'a> {
     pub exponent: &'a str,
     #[serde(rename = "n")]
     pub modulus: &'a str,
+    pub issuer: &'a str,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -41,7 +41,10 @@ pub fn validate_token_rs256<CustomClaims: Serialize + DeserializeOwned>(
     // Verify the token's claims.
     // Custom claims are also supported – see https://docs.rs/jwt-simple/0.9.3/jwt_simple/index.html#custom-claims
     let verification_options = VerificationOptions {
-        allowed_issuers: Some(HashSet::from_strings(&[key_metadata.issuer])),
+        allowed_issuers: Some(HashSet::from_strings(&[
+            key_metadata.issuer,
+            settings.openid_configuration.issuer
+        ])),
         allowed_audiences: Some(HashSet::from_strings(&[settings.config.client_id])),
         ..Default::default()
     };

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -43,7 +43,7 @@ pub fn validate_token_rs256<CustomClaims: Serialize + DeserializeOwned>(
     let verification_options = VerificationOptions {
         allowed_issuers: Some(HashSet::from_strings(&[
             key_metadata.issuer,
-            settings.openid_configuration.issuer
+            settings.openid_configuration.issuer,
         ])),
         allowed_audiences: Some(HashSet::from_strings(&[settings.config.client_id])),
         ..Default::default()

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -41,9 +41,7 @@ pub fn validate_token_rs256<CustomClaims: Serialize + DeserializeOwned>(
     // Verify the token's claims.
     // Custom claims are also supported – see https://docs.rs/jwt-simple/0.9.3/jwt_simple/index.html#custom-claims
     let verification_options = VerificationOptions {
-        allowed_issuers: Some(HashSet::from_strings(&[settings
-            .openid_configuration
-            .issuer])),
+        allowed_issuers: Some(HashSet::from_strings(&[key_metadata.issuer])),
         allowed_audiences: Some(HashSet::from_strings(&[settings.config.client_id])),
         ..Default::default()
     };


### PR DESCRIPTION
Some IdPs (e.g. [Azure](https://login.microsoftonline.com/common/discovery/v2.0/keys), when MS Live sign-in support is enabled) provide tenant-specific and public keys in the same JWKSet, while only the tenant-specific `issuer` will be exposed in the OIDC configuration metadata. 

This PR updates RS256 JWT validation so that issuers associated with either a public key OR the OIDC configuration are verified, which we ought to have done in the first place.