### PR TITLE
Safe Handling of Invalid UTF-8 in the Cookie Header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main(mut req: Request) -> Result<Response, Error> {
     let settings = Config::load();
 
     // Parse the Cookie header.
-    let cookie_header = req.remove_header_str("cookie").unwrap_or_default();
+    let cookie_header = req.remove_header_str_lossy("cookie").unwrap_or_default();
     let cookie = cookies::parse(&cookie_header);
 
     // Build the OAuth 2.0 redirect URL.


### PR DESCRIPTION
In the current implementation, the presence of invalid UTF-8 strings in the Cookie header causes a panic, leading to a 500 response. This PR addresses the issue by using `remove_header_str_lossy()`. With this update, the service will no longer panic with such headers. Invalid UTF-8 strings will be replaced with the U+FFFD REPLACEMENT CHARACTER (�).
