### PR TITLE
2025 Rust starter kit upgrades

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
-[target.wasm32-wasi]
-rustflags = ["-C", "debuginfo=2"]
-
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
+
+[term]
+color = "always"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,50 +1,14 @@
-on: pull_request
 name: Test
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'rust-toolchain.toml'
+      - '.cargo/config.toml'
+      - '.github/workflows/test.yml'
+      - 'src/**'
+
 jobs:
   test:
-    strategy:
-      matrix:
-        rust-toolchain: [1.83.0]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    environment: test
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.83.0
-      with:
-        toolchain: ${{ matrix.rust-toolchain }}
-        targets: wasm32-wasi
-        components: clippy, rustfmt
-    - name: Install audit
-      run: cargo install cargo-audit
-      shell: bash 
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo index
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v3
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-    - name: Store secrets
-      run: |
-        echo "${{ secrets.CLIENT_ID }}" > .secrets.client_id
-        echo "${{ secrets.CLIENT_SECRET }}" > .secrets.client_secret
-        dd if=/dev/random bs=32 count=1 | base64 > .secret.nonce_secret 
-    - name: Check binaries and format
-      run: RUSTFLAGS="--deny warnings" cargo check --bins --target wasm32-wasi && cargo fmt -- --check
-    - name: Run clippy
-      run: cargo clippy
-    - name: Run audit
-      run: cargo audit
-    - name: Run build
-      run: cargo build
+    uses: fastly/devex-reusable-workflows/.github/workflows/compute-starter-kit-rust-v1.yml@main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,15 @@
 name = "compute-rust-auth"
 version = "0.4.0"
 authors = []
-edition = "2018"
+edition = "2021"
+# Remove this line if you want to be able to publish this crate on crates.io.
+# Otherwise, `publish = false` prevents an accidental `cargo publish` from revealing private source.
+publish = false
 
 [profile.release]
-debug = true
+debug = 1
+codegen-units = 1
+lto = "fat"
 
 [dependencies]
 fastly = "0.11.2"

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,8 +1,14 @@
-authors = ["<oss@fastly.com>"]
+# This file describes a Fastly Compute package. To learn more visit:
+# https://www.fastly.com/documentation/reference/compute/fastly-toml/
+
 name = "Auth at edge with OAuth 2.0"
 description = "Connect to an identity provider such as Google using OAuth 2.0 and validate authentication status at the Edge, to authorize access to your edge or origin hosted applications."
+authors = ["<devrel@fastly.com>"]
 language = "rust"
 manifest_version = 3
+
+[scripts]
+  build = "cargo build --profile release"
 
 [setup]
 
@@ -20,7 +26,7 @@ manifest_version = 3
 
     [setup.secret_stores.oauth_secrets]
       description = "Store for authentication secrets"
- 
+
     [setup.secret_stores.oauth_secrets.entries]
 
         [setup.secret_stores.oauth_secrets.entries.client_id]
@@ -29,7 +35,7 @@ manifest_version = 3
         [setup.secret_stores.oauth_secrets.entries.nonce_secret]
           description = "A random secret to verify the OpenID nonce used to mitigate replay attacks."
 
-        # Optional client secret for certain IdPs' token endpoint. 
+        # Optional client secret for certain IdPs' token endpoint.
         # WARNING: Including this parameter produces NON-NORMATIVE OAuth 2.0 token requests.
         # Comment out if not required.
         [setup.secret_stores.oauth_secrets.entries.client_secret]
@@ -45,7 +51,7 @@ manifest_version = 3
         [setup.config_stores.oauth_config.items.openid_configuration]
           description = "OpenID Connect (OIDC) discovery document containing OAuth 2.0 endpoints. This is usually obtained from https://YOUR_AUTH_SERVER/.well-known/openid-configuration"
           input_type = "string"
-         
+
         [setup.config_stores.oauth_config.items.jwks]
           description = "JSON Web Key Set (JWKS) containing the public keys used to verify the JWT signature. You can find this at the jwks_uri endpoint in the OIDC discovery document."
           input_type = "string"
@@ -73,7 +79,7 @@ manifest_version = 3
       key = "nonce_secret"
       file = ".secret.nonce_secret"
 
-    # Optional client secret for certain IdPs' token endpoint. 
+    # Optional client secret for certain IdPs' token endpoint.
     # WARNING: Including this parameter produces NON-NORMATIVE OAuth 2.0 token requests.
     # Comment out if not required.
     [[local_server.secret_stores.oauth_secrets]]
@@ -85,7 +91,7 @@ manifest_version = 3
     [local_server.config_stores.oauth_config]
       format = "inline-toml"
 
-      [local_server.config_stores.oauth_config.contents] 
+      [local_server.config_stores.oauth_config.contents]
         openid_configuration = "{\"issuer\":\"https://accounts.google.com\",\"authorization_endpoint\":\"https://accounts.google.com/o/oauth2/v2/auth\",\"device_authorization_endpoint\":\"https://oauth2.googleapis.com/device/code\",\"token_endpoint\":\"https://oauth2.googleapis.com/token\",\"userinfo_endpoint\":\"https://openidconnect.googleapis.com/v1/userinfo\",\"revocation_endpoint\":\"https://oauth2.googleapis.com/revoke\",\"jwks_uri\":\"https://www.googleapis.com/oauth2/v3/certs\",\"response_types_supported\":[\"code\",\"token\",\"id_token\",\"code token\",\"code id_token\",\"token id_token\",\"code token id_token\",\"none\"],\"subject_types_supported\":[\"public\"],\"id_token_signing_alg_values_supported\":[\"RS256\"],\"scopes_supported\":[\"openid\",\"email\",\"profile\"],\"token_endpoint_auth_methods_supported\":[\"client_secret_post\",\"client_secret_basic\"],\"claims_supported\":[\"aud\",\"email\",\"email_verified\",\"exp\",\"family_name\",\"given_name\",\"iat\",\"iss\",\"locale\",\"name\",\"picture\",\"sub\"],\"code_challenge_methods_supported\":[\"plain\",\"S256\"],\"grant_types_supported\":[\"authorization_code\",\"refresh_token\",\"urn:ietf:params:oauth:grant-type:device_code\",\"urn:ietf:params:oauth:grant-type:jwt-bearer\"]}"
         jwks = "{\"keys\":[{\"e\":\"AQAB\",\"kty\":\"RSA\",\"n\":\"4bAT6C6EeX8Dspje3FrAXw-nnhNk04e1RmNa4kjc0CHf6Pk7ryARlwA-6YilyPABqQfYHx60s8oSnxvUVprFfQ2-Q8aAZO7bPKSxnoGlcKERL2oLNA4Msvc89N9Y5ycThZUplf_QC19e6jyYXN6Nz-UnJSCLrtQY8tVhhVRs61j4A2N_p-enAi-r704Qi1-v-DKV4eVRkClKViploo8NyjUaT9L4vbBssPCjyimJzsWnEe1fED5c4LnHeArYzA_FEn3JJotqDIz9t2VnvZNTMhizHEX4VnORlEWMEfR8n4CEHQx7PcQUOmfqyw08gWeXQl1-uTjtIGaE-sRIv9u_vQ\",\"alg\":\"RS256\",\"kid\":\"2af90e87be140c20038898a6efa11283dab6031d\",\"use\":\"sig\"},{\"n\":\"nzGsrziOYrMVYMpvUZOwkKNiPWcOPTYRYlDSdRW4UpAHdWPbPlyqaaphYhoMB5DXrVxI3bdvm7DOlo-sHNnulmAFQa-7TsQMxrZCvVdAbyXGID9DZYEqf8mkCV1Ohv7WY5lDUqlybIk1OSHdK7-1et0QS8nn-5LojGg8FK4ssLf3mV1APpujl27D1bDhyRb1MGumXYElwlUms7F9p9OcSp5pTevXCLmXs9MJJk4o9E1zzPpQ9Ko0lH9l_UqFpA7vwQhnw0nbh73rXOX2TUDCUqL4ThKU5Z9Pd-eZCEOatKe0mJTpQ00XGACBME_6ojCdfNIJr84Y_IpGKvkAEksn9w\",\"kty\":\"RSA\",\"alg\":\"RS256\",\"e\":\"AQAB\",\"kid\":\"87bbe0815b064e6d449cac999f0e50e72a3e4374\",\"use\":\"sig\"}]}"
         callback_path = "/callback"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.83.0"
-targets = [ "wasm32-wasi" ]
+channel = "stable"
+targets = [ "wasm32-wasip1" ]
+profile = "default"

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,17 +57,17 @@ impl Config {
         let secrets =
             SecretStore::open("oauth_secrets").expect("Could not open oauth_secrets secret store");
 
-        let get_secret = |key: &str| match secrets.get(key) {
-            Some(secret) => Some(
+        let get_secret = |key: &str| {
+            secrets.get(key).map(|secret| {
                 std::str::from_utf8(&secret.plaintext())
                     .unwrap()
-                    .to_string(),
-            ),
-            _ => None,
+                    .to_string()
+            })
         };
 
-        let require_secret =
-            |key: &str| get_secret(key).expect(&format!("Required secret {} not found", key));
+        let require_secret = |key: &str| {
+            get_secret(key).unwrap_or_else(|| panic!("Required secret {} not found", key))
+        };
 
         let cfg = ConfigStore::open("oauth_config");
         let jwks = cfg.get("jwks").expect("JWKS metadata not found");


### PR DESCRIPTION
Starter kit content changes:

* Changed 'wasm32-wasi' target to 'wasm32-wasip1' (requires Rust 1.78 or later and Fastly CLI 11.0 or later)

* Changed rust-toolchain.toml to install 'stable' toolchain instead of '1.83.0'

* Moved term.color=always from scripts.build in fastly.toml to .cargo/config.toml

* Updated Rust edition from 2018 to 2021

* Changed Rust 'release' profile to use LTO

* Removed unnecessary parameters from scripts.build in fastly.toml

* 'cargo clippy' fixes

Other changes:

* Switched to using a reusable workflow for CI