### PR TITLE
Validate the redirect target

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,8 +175,9 @@ fn main(mut req: Request) -> Result<Response, Error> {
     let state = {
         let path = req.get_path();
         if !is_safe_redirect_target(path) {
-            return Ok(Response::from_status(StatusCode::BAD_REQUEST)
-                .with_body("Invalid request path."));
+            return Ok(
+                Response::from_status(StatusCode::BAD_REQUEST).with_body("Invalid request path.")
+            );
         }
         let (sep, query) = match req.get_query_str() {
             Some(q) => ("?", q),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,19 @@ mod pkce;
 mod responses;
 
 use config::Config;
-use fastly::http::header::AUTHORIZATION;
+use fastly::http::{header::AUTHORIZATION, StatusCode};
 use fastly::{Error, Request, Response};
 use idp::{AuthCodePayload, AuthorizeResponse, CallbackQueryParameters, ExchangePayload};
 use jwt::{validate_token_rs256, NonceToken};
 use jwt_simple::claims::NoCustomClaims;
 use pkce::{rand_chars, Pkce};
+
+fn is_safe_redirect_target(s: &str) -> bool {
+    s.starts_with('/')
+        && !s.starts_with("//")
+        && !s.contains('\\')
+        && !s.chars().any(char::is_control)
+}
 
 #[fastly::main]
 fn main(mut req: Request) -> Result<Response, Error> {
@@ -90,6 +97,10 @@ fn main(mut req: Request) -> Result<Response, Error> {
                     // Strip the random state from the state cookie value to get the original request.
                     let original_req =
                         &state[..(state.len() - settings.config.state_parameter_length)];
+                    if !is_safe_redirect_target(original_req) {
+                        return Ok(Response::from_status(StatusCode::BAD_REQUEST)
+                            .with_body("Invalid redirect target."));
+                    }
                     // Deserialize the response from the authorize step.
                     let auth = exchange_res.take_body_json::<AuthorizeResponse>().unwrap();
                     // Replay the original request, setting the tokens as cookies.
@@ -163,6 +174,10 @@ fn main(mut req: Request) -> Result<Response, Error> {
     // and store the original request path and query string.
     let state = {
         let path = req.get_path();
+        if !is_safe_redirect_target(path) {
+            return Ok(Response::from_status(StatusCode::BAD_REQUEST)
+                .with_body("Invalid request path."));
+        }
         let (sep, query) = match req.get_query_str() {
             Some(q) => ("?", q),
             None => ("", ""),


### PR DESCRIPTION
When a client connects to https://example.com/<path>, the state cookie is set to `<path><10 random chars>` .

And after successful authentication, we issue a 307 redirect to the location `<path>`.

We didn't perform any validation on `<path>`. The signature only proves that the cookie wasn't tampered with, not that `<path>` was safe. The server signs whatever path the original request happened to have.

Problem with a 30x redirect:

- If the location starts with // it is interpreted as a host name (`//evil.com` -> https://evil.com)

Also:
- WHATWG treats `\` like `/`, so `\/` for example would parsed the same as `//`
- WHATWG strips ASCII tab and newline before parsing, so a redirect to `/<TAB>/evil.com` would be equivalent to //evil.com

This open redirect is a convenient phishing primitive: the user just authenticated, sees the real domain in the URL bar through the entire OAuth dance, and lands on attacker territory primed to be told "session expired, please re-enter your password" or to be served a fake consent screen.

That also works because Compute doesn't seem to be doing any URL normalization (such as`//` -> `/`).

So, add validation.